### PR TITLE
The requested branch should be 3.2-maint.

### DIFF
--- a/meta/recipes-devtools/distcc/distcc_3.2-maint.bb
+++ b/meta/recipes-devtools/distcc/distcc_3.2-maint.bb
@@ -21,7 +21,7 @@ SRC_URI = "git://github.com/distcc/distcc.git;branch=${PV} \
            file://distccmon-gnome.desktop \
            file://distcc \
            file://distcc.service"
-SRCREV = "d8b18df3e9dcbe4f092bed565835d3975e99432c"
+SRCREV = "${AUTOREV}"
 S = "${WORKDIR}/git"
 UPSTREAM_VERSION_UNKNOWN = "1"
 

--- a/meta/recipes-devtools/distcc/distcc_3.2-maint.bb
+++ b/meta/recipes-devtools/distcc/distcc_3.2-maint.bb
@@ -27,7 +27,7 @@ UPSTREAM_VERSION_UNKNOWN = "1"
 
 inherit autotools pkgconfig update-rc.d useradd systemd
 
-EXTRA_OECONF += "--disable-Werror PYTHON='' --disable-pump-mode"
+EXTRA_OECONF += "--disable-Werror PYTHON=''"
 
 USERADD_PACKAGES = "${PN}"
 USERADD_PARAM_${PN} = "--system \


### PR DESCRIPTION
Patchwork changes:

1. Renames distcc_3.2.bb to distcc_3.2-maint.bb to match the correct branch upstream. See https://github.com/distcc/distcc/tree/3.2-maint.

2. Let's set `SRCREV = "${AUTOREV}"` as it should just work. 

This should fix the build error encountered when building Yocto for Xilinx based on the R2018.2 release.